### PR TITLE
Regex answer checks

### DIFF
--- a/ScavengerHunt/Model/TargetRegion.swift
+++ b/ScavengerHunt/Model/TargetRegion.swift
@@ -14,6 +14,6 @@ struct TargetRegion {
     let radius: CLLocationDistance
     let identifier: String
     let question: String
-    let answer: String
+    let answer: any RegexComponent
     var completed: Bool
 }

--- a/ScavengerHunt/ViewModels/TargetsViewModel.swift
+++ b/ScavengerHunt/ViewModels/TargetsViewModel.swift
@@ -21,7 +21,7 @@ class TargetsViewModel {
             radius: 8,
             identifier: "John Runza's House",
             question: "He guided the flock at LCS for many years – what is the name of the house he lives in?",
-            answer: "Hillcot",
+            answer: /hillcot/.ignoresCase(),
             completed: false
         ),
         
@@ -31,7 +31,7 @@ class TargetsViewModel {
             radius: 8,
             identifier: "Academic Block Sign",
             question: "What family sponsored the construction of the Academic Block?",
-            answer: "Desmarais",
+            answer: /desmarais/.ignoresCase(),
             completed: false
         ),
         

--- a/ScavengerHunt/Views/PositionView.swift
+++ b/ScavengerHunt/Views/PositionView.swift
@@ -83,7 +83,7 @@ struct PositionView: View {
                 TextField("What is the answer to the question?", text: $currentAnswer)
                 
                 Button {
-                    if currentAnswer == targetsViewModel.getCurrentTarget().answer {
+                    if currentAnswer.contains( targetsViewModel.getCurrentTarget().answer) {
                         
                         // Mark current target as completed
                         targetsViewModel.targets[targetsViewModel.currentTargetIndex].completed = true


### PR DESCRIPTION
This allows for users to have a bit of variation with their answers

There are no related issues on Github, however I've seen people attempt to type `Hillcot house` or even just `hillcot `, whilst being marked incorrect.

This is open to any changes to how it checks since I sort of slapped this together and #contains() was the best I could find for this situation.